### PR TITLE
Fix Quaternion::to_euler

### DIFF
--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -307,23 +307,23 @@ macro_rules! create_quaternion {
             /// Most sources online provide us with results that do not behave how we expect.
             pub fn to_euler(&self) -> EulerAngle {
                 let w = self.w;
-                let x = self.y;
-                let y = self.x;
+                let x = self.x;
+                let y = self.y;
                 let z = self.z;
 
                 // half z-component of x' (negated)
                 let xz = w * y - x * z;
 
                 let yaw = (x * y + w * z).atan2(0.5 - (y * y + z * z));
-                let pitch = -(xz / (0.25 - xz * xz).sqrt()).atan();
+                let pitch = (xz / (0.25 - xz * xz).sqrt()).atan();
 
                 const YPR_GIMBAL_LOCK: $f = 100.; // todo: Currently always uses logic A.
 
                 let roll = if (xz.abs()) < YPR_GIMBAL_LOCK {
-                    y * z + w * x.atan2(0.5 - (x * x + y * y))
+                    (y * z + w * x).atan2(0.5 - (x * x + y * y))
                 } else {
                     2.0 * x.atan2(w) + xz.signum() * yaw
-                } * -1.;
+                };
 
                 EulerAngle { pitch, roll, yaw }
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,23 @@
-use std::f32::consts::TAU;
+use std::f32::consts::{FRAC_PI_2, TAU};
 
 use super::*;
 use crate::f32::{self, X_VEC, Y_VEC, Z_VEC, f32x8, pack_vec3x8, pack_x8, unpack_x8};
+
+/// Assert that two f32 expressions are equal up to machine precision
+///
+/// The assertion is done by comparing the absolute difference to be less or equal than f32::EPSILON
+///
+/// On panic, this macro will print the values of the expressions with their debug representations.
+macro_rules! assert_eq_f32 {
+    ($left:expr, $right:expr) => {
+        let (left, right): (f32, f32) = ($left, $right);
+
+        assert!(
+            (left - right).abs() <= f32::EPSILON,
+            "assertion `left == right` failed (up to f32::EPSILON)\n  left: {left}\n right: {right}"
+        );
+    };
+}
 
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]
 #[test]
@@ -251,9 +267,36 @@ fn test_quaternion_from_and_to_euler() {
     // you might verify that euler2.pitch ~ 0, euler2.roll ~ pi/2, euler2.yaw ~ pi/2
     // within some tolerance
 
-    // assert!((euler2.roll - std::f32::consts::FRAC_PI_2).abs() < 0.2);
-    assert!((euler2.pitch - 0.0).abs() < 0.2);
-    assert!((euler2.yaw - std::f32::consts::FRAC_PI_2).abs() < 0.2);
+    assert_eq_f32!(euler2.roll, std::f32::consts::FRAC_PI_2);
+    assert_eq_f32!(euler2.pitch, 0.0);
+    assert_eq_f32!(euler2.yaw, std::f32::consts::FRAC_PI_2);
+}
+
+#[test]
+fn test_quaternion_to_euler() {
+    let q = f32::Quaternion::from_axis_angle(X_VEC, 0.5);
+    let euler = q.to_euler();
+    assert_eq_f32!(euler.roll, 0.5);
+    assert_eq_f32!(euler.pitch, 0.0);
+    assert_eq_f32!(euler.yaw, 0.0);
+
+    let q = f32::Quaternion::from_axis_angle(Y_VEC, 0.5);
+    let euler = q.to_euler();
+    assert_eq_f32!(euler.roll, 0.0);
+    assert_eq_f32!(euler.pitch, 0.5);
+    assert_eq_f32!(euler.yaw, 0.0);
+
+    let q = f32::Quaternion::from_axis_angle(Z_VEC, 0.5);
+    let euler = q.to_euler();
+    assert_eq_f32!(euler.roll, 0.0);
+    assert_eq_f32!(euler.pitch, 0.0);
+    assert_eq_f32!(euler.yaw, 0.5);
+
+    let q = f32::Quaternion::new(0.5, 0.5, 0.5, 0.5);
+    let euler = q.to_euler();
+    assert_eq_f32!(euler.roll, FRAC_PI_2);
+    assert_eq_f32!(euler.pitch, 0.0);
+    assert_eq_f32!(euler.yaw, FRAC_PI_2);
 }
 
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "std"))]


### PR DESCRIPTION
Hi,
I played around with the crate and noticed an issue with `Quaternion::to_euler`. I had a look at the linked blog post, fixed the implementation and added some more test cases.

Note: The test `test_simd_rotate_vec` is currently failing. As far as I can tell this is due to a mix up of the components of the expected `angled` vector in the testcase. If you want I can fix this in this PR as well or do a separate PR.